### PR TITLE
build: Add a Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 *.patch
-cva
+agent

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+SOURCES := $(shell find . 2>&1 | grep -E '.*\.(c|h|go)$$')
+
+TARGET = agent
+
+.DEFAULT: $(TARGET)
+$(TARGET): $(SOURCES) Makefile
+	go build -o $@ .
+
+clean:
+	rm -f $(TARGET)


### PR DESCRIPTION
Add a Makefile allows to build and clean the "agent" binary. The gitignore file has been updated accordingly.