### PR TITLE
agent: Enable no keys flag

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -871,6 +871,8 @@ func newContainerCb(pod *pod, data []byte) error {
 				Flags:       defaultMountFlags | unix.MS_RDONLY,
 			},
 		},
+
+		NoNewKeyring: true,
 	}
 
 	containerPath := filepath.Join("/tmp/libcontainer", pod.id)


### PR DESCRIPTION
Enabling this flag allows our agent to run on guest kernel without CONFIG_KEYS option enabled inside the kernel.