### PR TITLE
api: Fix exec command

### DIFF
--- a/api/commands.go
+++ b/api/commands.go
@@ -57,7 +57,7 @@ var stringCmdList = map[HyperCmd]string{
 	NewContainerCmd:    "newcontainer",
 	KillContainerCmd:   "killcontainer",
 	RemoveContainerCmd: "removecontainer",
-	ExecCmd:            "exec",
+	ExecCmd:            "execcmd",
 	ReadyCmd:           "ready",
 	AckCmd:             "ack",
 	ErrorCmd:           "error",


### PR DESCRIPTION
"exec" string representing Exec command is not the one expected by hyperstart protocol. Replace "exec" with "execcmd".