### PR TITLE
hack: agent-cli: Add agent-cli tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.patch
 agent
+/hack/agent-cli/agent-cli

--- a/hack/agent-cli/README.md
+++ b/hack/agent-cli/README.md
@@ -1,0 +1,138 @@
+# Agent CLI
+
+## Usage
+
+### Start your VM
+
+```
+sudo /usr/bin/qemu-lite-system-x86_64 -name "4933b48bb99bfa8c" -machine pc-lite,accel=kvm,kernel_irqchip,nvdimm -device nvdimm,memdev=mem0,id=nv0 -object "memory-backend-file,id=mem0,mem-path=/usr/share/clear-containers/clear-containers.img,size=235929600" -m "2G,slots=2,maxmem=3G" -smp 2,sockets=2,cores=1,threads=1 -cpu host -no-user-config -nodefaults -no-hpet -global kvm-pit.lost_tick_policy=discard -chardev stdio,signal=off,id=charconsole0 -device virtio-serial-pci,id=virtio-serial0 -device virtconsole,bus=virtio-serial0.0,chardev=charconsole0,id=console0,name=console0 -uuid a877689d-284e-4544-90a7-ed390a76ef57 -chardev socket,id=charch0,path=/tmp/hyper.sock,server,nowait -device virtserialport,bus=virtio-serial0.0,nr=1,chardev=charch0,id=channel0,name=sh.hyper.channel.0 -chardev socket,id=charch1,path=/tmp/tty.sock,server,nowait -device virtserialport,bus=virtio-serial0.0,nr=2,chardev=charch1,id=channel1,name=sh.hyper.channel.1 -chardev socket,path=/tmp/monitor_4933b48bb99bfa8c.sock,server,nowait,id=charmonitor -mon chardev=charmonitor -nographic -vga none  -kernel "/usr/share/clear-containers/vmlinux.container" -append " root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 cryptomgr.notests i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 initcall_debug init=/usr/lib/systemd/systemd iommu=off" -device virtio-9p-pci,fsdev=shared,mount_tag=shared -fsdev local,id=shared,path=<your_rootfs>,security_model=none
+```
+Make sure you replace "your rootfs" with the rootfs of your choice. And make sure your clear-containers.img includes `agent` binary.
+
+Enter `root` as login, and choose a password.
+
+### Run the agent
+
+From the VM shell:
+
+```
+hyperstart
+```
+
+### Run agent-cli
+
+From a different shell on the host:
+```
+./agent-cli run --ctl=/tmp/hyper.sock --tty=/tmp/tty.sock
+```
+
+### Basic usage
+
+To exit the tool, choose command "100"
+
+To send to TTY, choose command "50".
+
+To send to CTL, choose any other command.
+
+### Complete example
+
+__Start a pod__
+
+```
+Command: 1 
+Payload: {"hostname":"30028dfd-4904-4818-a2cf-9419bdc7e2d4","shareDir":"shared"}
+```
+
+Output
+
+```
+DecodedMessage {
+        Code: 9
+        Message: 
+}
+```
+
+__Start a new container__
+
+```
+Command: 9
+Payload: {"id":"1","rootfs":"rootfs","image":"","process":{"terminal":false,"stdio":3,"stderr":4,"args":["/bin/ifconfig"],"workdir":"/"}}
+```
+Output
+
+```
+TtyMessage {
+        Session: 3
+        Message: lo        Link encap:Local Loopback  
+          inet addr:127.0.0.1  Mask:255.0.0.0
+          inet6 addr: ::1/128 Scope:Host
+          UP LOOPBACK RUNNING  MTU:65536  Metric:1
+          RX packets:288 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:288 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1 
+          RX bytes:23904 (23.3 KiB)  TX bytes:23904 (23.3 KiB)
+
+
+}
+DecodedMessage {
+        Code: 9
+        Message: 
+}
+Command: 
+TtyMessage {
+        Session: 3
+        Message: 
+}
+
+Command: 
+TtyMessage {
+        Session: 3
+        Message: 
+}
+```
+
+__Execute an additional command on a running container__
+
+```
+Command: 3
+Payload: {"container":"1","process":{"terminal":false,"stdio":5,"stderr":6,"args":["/bin/ifconfig"],"envs":[{"env":"PATH","value":"/bin:/usr/bin:/sbin:/usr/sbin"}],"workdir":"/"}}
+```
+Output
+
+```
+DecodedMessage {
+        Code: 9
+        Message: 
+}
+Command: 
+TtyMessage {
+        Session: a
+        Message: lo        Link encap:Local Loopback  
+          inet addr:127.0.0.1  Mask:255.0.0.0
+          inet6 addr: ::1/128 Scope:Host
+          UP LOOPBACK RUNNING  MTU:65536  Metric:1
+          RX packets:160 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:160 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1 
+          RX bytes:13024 (12.7 KiB)  TX bytes:13024 (12.7 KiB)
+
+
+}
+
+Command: 
+TtyMessage {
+        Session: a
+        Message: 
+}
+
+Command: 
+TtyMessage {
+        Session: a
+        Message: 
+}
+```
+
+Make sure the container that you have previously started has not returned yet, otherwise you will get similar error from the agent inside the VM:
+```
+ERRO[0372] Run "exec" command failed: Container 1 not running, impossible to execute process 10
+```

--- a/hack/agent-cli/agent_cli.go
+++ b/hack/agent-cli/agent_cli.go
@@ -1,0 +1,327 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/golang/glog"
+	"github.com/urfave/cli"
+
+	agentApi "github.com/clearcontainers/agent/api"
+	"github.com/containers/virtcontainers/pkg/hyperstart"
+)
+
+const unixSocketType = "unix"
+
+const (
+	commandInputMsg  = "Command: "
+	sequenceInputMsg = "Sequence: "
+	payloadInputMsg  = "Payload: "
+)
+
+const (
+	sendTty = "tty"
+	exit    = "exit"
+)
+
+var cmdList = map[int]string{
+	1:   agentApi.CmdToString(agentApi.StartPodCmd),
+	2:   agentApi.CmdToString(agentApi.DestroyPodCmd),
+	3:   agentApi.CmdToString(agentApi.ExecCmd),
+	4:   agentApi.CmdToString(agentApi.ReadyCmd),
+	5:   agentApi.CmdToString(agentApi.AckCmd),
+	6:   agentApi.CmdToString(agentApi.ErrorCmd),
+	7:   agentApi.CmdToString(agentApi.WinsizeCmd),
+	8:   agentApi.CmdToString(agentApi.PingCmd),
+	9:   agentApi.CmdToString(agentApi.NewContainerCmd),
+	10:  agentApi.CmdToString(agentApi.KillContainerCmd),
+	11:  agentApi.CmdToString(agentApi.RemoveContainerCmd),
+	50:  sendTty,
+	100: exit,
+}
+
+var waitingInput = false
+var waitingInputText = ""
+
+func magicLog(format string, args ...interface{}) {
+	waitInput, waitInputText := getWaitingInputs()
+
+	if waitInput == true {
+		fmt.Println("")
+	}
+
+	fmt.Printf(format, args...)
+
+	if waitInput == true {
+		fmt.Println("")
+		fmt.Printf(waitInputText)
+	}
+}
+
+func setWaitingInputs(input bool, inputText string) {
+	waitingInput = input
+	waitingInputText = inputText
+}
+
+func getWaitingInputs() (bool, string) {
+	return waitingInput, waitingInputText
+}
+
+func dumpSupportedCommands() {
+	magicLog("== Supported commands ==\n")
+	magicLog("  1 - STARTPOD\n")
+	magicLog("  2 - DESTROYPOD\n")
+	magicLog("  3 - EXECCMD\n")
+	magicLog("  4 - READY\n")
+	magicLog("  5 - ACK\n")
+	magicLog("  6 - ERROR\n")
+	magicLog("  7 - WINSIZE\n")
+	magicLog("  8 - PING\n")
+	magicLog("  9 - NEWCONTAINER\n")
+	magicLog(" 10 - KILLCONTAINER\n")
+	magicLog(" 11 - REMOVECONTAINER\n")
+	magicLog(" 50 - TTY SEQUENCE\n")
+	magicLog("100 - EXIT\n\n")
+}
+
+func dumpFrame(msg interface{}) {
+	switch m := msg.(type) {
+	case hyperstart.DecodedMessage:
+		magicLog("DecodedMessage {\n\tCode: %x\n\tMessage: %s\n}\n", m.Code, m.Message)
+	case hyperstart.TtyMessage:
+		magicLog("TtyMessage {\n\tSession: %x\n\tMessage: %s\n}\n", m.Session, m.Message)
+	}
+}
+
+func readStringNoDelimiter(reader *bufio.Reader, delim byte) (string, error) {
+	input, err := reader.ReadBytes('\n')
+	if err != nil {
+		return "", err
+	}
+
+	strInput := string(input[:len(input)-1])
+
+	return strInput, nil
+}
+
+func convertInputToCmd(input string) (string, error) {
+	intInput, err := strconv.Atoi(input)
+	if err != nil {
+		return "", err
+	}
+
+	_, ok := cmdList[intInput]
+	if ok == false {
+		return "", fmt.Errorf("%d is not a valid command", intInput)
+	}
+
+	return cmdList[intInput], nil
+}
+
+func sendMessage(h *hyperstart.Hyperstart, ctlType bool, cmd string, payload string) error {
+	payloadSlice, err := hyperstart.FormatMessage(payload)
+	if err != nil {
+		return err
+	}
+
+	if ctlType == true {
+		msg, err := h.SendCtlMessage(cmd, payloadSlice)
+		if err != nil {
+			return err
+		}
+
+		if msg != nil {
+			dumpFrame(*msg)
+		}
+	} else {
+		seq, err := strconv.ParseUint(cmd, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		ttyMsg := &hyperstart.TtyMessage{
+			Session: seq,
+			Message: payloadSlice,
+		}
+
+		err = h.SendIoMessage(ttyMsg)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func monitorStdInLoop(h *hyperstart.Hyperstart, done chan<- bool) error {
+	dumpSupportedCommands()
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		magicLog(commandInputMsg)
+		setWaitingInputs(true, commandInputMsg)
+		input, err := readStringNoDelimiter(reader, '\n')
+		if err != nil {
+			setWaitingInputs(false, "")
+			magicLog("%s\n", err)
+			break
+		}
+		setWaitingInputs(false, "")
+
+		if input == "" {
+			continue
+		}
+
+		cmd, err := convertInputToCmd(input)
+		if err != nil {
+			magicLog("%s\n", err)
+			continue
+		}
+
+		if cmd == exit {
+			break
+		}
+
+		ctlType := true
+
+		if cmd == sendTty {
+			ctlType = false
+			magicLog(sequenceInputMsg)
+			setWaitingInputs(true, sequenceInputMsg)
+			cmd, err = readStringNoDelimiter(reader, '\n')
+			if err != nil {
+				setWaitingInputs(false, "")
+				magicLog("%s\n", err)
+				break
+			}
+			setWaitingInputs(false, "")
+		}
+
+		magicLog(payloadInputMsg)
+		setWaitingInputs(true, payloadInputMsg)
+		payload, err := readStringNoDelimiter(reader, '\n')
+		if err != nil {
+			setWaitingInputs(false, "")
+			magicLog("%s\n", err)
+			break
+		}
+		setWaitingInputs(false, "")
+
+		err = sendMessage(h, ctlType, cmd, payload)
+		if err != nil {
+			magicLog("%s\n", err)
+			continue
+		}
+	}
+
+	done <- true
+	return nil
+}
+
+func monitorTtyOutLoop(h *hyperstart.Hyperstart, done chan<- bool) error {
+	for {
+		msgCh := make(chan *hyperstart.TtyMessage, 1)
+		errorCh := make(chan bool, 1)
+
+		go func() {
+			msg, err := h.ReadIoMessage()
+			if err != nil {
+				magicLog("%s\n", err)
+				errorCh <- true
+				return
+			}
+
+			msgCh <- msg
+		}()
+
+		select {
+		case msg := <-msgCh:
+			dumpFrame(*msg)
+		case <-errorCh:
+			done <- true
+			break
+		}
+	}
+}
+
+func mainLoop(c *cli.Context) error {
+	ctlSockPath := c.String("ctl")
+	ttySockPath := c.String("tty")
+
+	if ctlSockPath == "" || ttySockPath == "" {
+		return fmt.Errorf("Missing socket path. Please provide CTL and TTY socket paths.")
+	}
+
+	h := hyperstart.NewHyperstart(ctlSockPath, ttySockPath, unixSocketType)
+
+	if err := h.OpenSockets(); err != nil {
+		return err
+	}
+	defer h.CloseSockets()
+
+	if err := h.WaitForReady(); err != nil {
+		return err
+	}
+
+	done := make(chan bool, 1)
+
+	go monitorStdInLoop(h, done)
+	go monitorTtyOutLoop(h, done)
+
+	<-done
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+
+	agentCli := cli.NewApp()
+	agentCli.Name = "Agent CLI"
+	agentCli.Version = "1.0.0"
+	agentCli.Commands = []cli.Command{
+		{
+			Name:  "run",
+			Usage: "send/receive on hyperstart sockets",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "ctl",
+					Value: "",
+					Usage: "the CTL socket path",
+				},
+				cli.StringFlag{
+					Name:  "tty",
+					Value: "",
+					Usage: "the TTY socket path",
+				},
+			},
+			Action: func(context *cli.Context) error {
+				return mainLoop(context)
+			},
+		},
+	}
+
+	err := agentCli.Run(os.Args)
+	if err != nil {
+		glog.Fatal(err)
+	}
+}


### PR DESCRIPTION
This commit introduces a new tool called agent-cli. It is very useful to debug the agent running inside the VM without setting up the entire chain with runtime, shim and proxy.