### PR TITLE
agent: Return ERROR if the executed process could not start

### DIFF
--- a/hack/agent-cli/agent_cli.go
+++ b/hack/agent-cli/agent_cli.go
@@ -268,7 +268,7 @@ func mainLoop(c *cli.Context) error {
 	ttySockPath := c.String("tty")
 
 	if ctlSockPath == "" || ttySockPath == "" {
-		return fmt.Errorf("Missing socket path. Please provide CTL and TTY socket paths.")
+		return fmt.Errorf("Missing socket path: please provide CTL and TTY socket paths")
 	}
 
 	h := hyperstart.NewHyperstart(ctlSockPath, ttySockPath, unixSocketType)


### PR DESCRIPTION
In case we cannot start the container process or any additional process on an existing container, we want to return ERROR through CTL channel.

Otherwise, the EXECCMD command would never fail because of the command that we try to run.