### PR TITLE
agent: Synchronize end of process to prevent from race condition

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -128,7 +128,7 @@ type pod struct {
 	stdinList  map[uint64]*os.File
 	network    hyper.Network
 	stdinLock  sync.Mutex
-	stdoutLock sync.Mutex
+	ttyLock    sync.Mutex
 }
 
 type cmdCb func(*pod, []byte) error
@@ -499,8 +499,8 @@ func (p *pod) sendCmd(cmd hyper.HyperCmd, data []byte) error {
 }
 
 func (p *pod) sendSeq(seq uint64, data []byte) error {
-	p.stdoutLock.Lock()
-	defer p.stdoutLock.Unlock()
+	p.ttyLock.Lock()
+	defer p.ttyLock.Unlock()
 
 	dataLen := len(data)
 	length := ttyHeaderSize + dataLen
@@ -548,6 +548,7 @@ func (p *pod) closeProcessStreams(cid, pid string) {
 func (p *pod) routeOutput(seq uint64, stream *os.File) {
 	for {
 		buf := make([]byte, 1024)
+
 		n, err := stream.Read(buf)
 		if err != nil {
 			agentLog.Infof("Stream %d has been closed: %v", seq, err)


### PR DESCRIPTION
In some cases, the agent returns the exit code before it has been able to forward all the output provided on stdout and stderr.

This is a race condition issue fixed by this patch. The idea is to wait for the end of every go routines, meaning there is nothing else to be read on stdout or stderr. That way, we ensure that all that have been received on stdout or stderr is properly sent to the proxy before to send the exit code and the exit pattern.

We have to close the pipes that we provided in case no terminal was setup. In case there is a terminal, then libcontainer will close the other end for us.

In both cases, when the other end is closed, the blocking read inside each go routines will fail and this will lead to its termination.