### PR TITLE
utils: Make sure to preserve all attributes when copying a file

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -21,7 +21,7 @@ import (
 	"os/exec"
 )
 
-const cpBinaryName = "cp"
+const cpBinaryName = "cp --preserve=all"
 
 func fileCopy(srcPath, dstPath string) error {
 	if srcPath == "" {


### PR DESCRIPTION
Adding --preserve=all to the 'cp' command ensures that we don't loose any attribute related to the file during the copy.