### PR TITLE
build: Add systemd unit files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.patch
-agent
+cc-agent
+clear-containers.service
 /hack/agent-cli/agent-cli

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,44 @@
 SOURCES := $(shell find . 2>&1 | grep -E '.*\.(c|h|go)$$')
 
-TARGET = agent
+TARGET = cc-agent
+DESTDIR :=
+PREFIX := /usr
+BINDIR := $(PREFIX)/bin
+
+
+HAVE_SYSTEMD := $(shell pkg-config --exists systemd 2>/dev/null && echo 'yes')
+
+ifeq ($(HAVE_SYSTEMD),yes)
+UNIT_DIR := $(shell pkg-config --variable=systemdsystemunitdir systemd)
+UNIT_FILES = clear-containers.service
+GENERATED_FILES := $(UNIT_FILES)
+UNIT_FILES += clear-containers.target
+endif
+
+SED = sed
 
 .DEFAULT: $(TARGET)
-$(TARGET): $(SOURCES) Makefile
+$(TARGET): $(SOURCES) Makefile $(GENERATED_FILES)
 	go build -o $@ .
 
+install:
+	install -D $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
+ifeq ($(HAVE_SYSTEMD),yes)
+	$(foreach f,$(UNIT_FILES),$(call INSTALL_FILE,$f,$(UNIT_DIR)))
+endif
+
+$(GENERATED_FILES): %: %.in Makefile
+	@mkdir -p `dirname $@`
+	$(QUIET_GEN)sed \
+		-e 's|[@]bindir[@]|$(BINDIR)|g' \
+		-e 's|[@]ccagent[@]|$(TARGET)|g' \
+		"$<" > "$@"
+
 clean:
-	rm -f $(TARGET)
+	rm -f $(TARGET) $(GENERATED_FILES)
+
+define INSTALL_FILE
+	$(QUIET_INST)install -D -m 644 $1 $(DESTDIR)$2/$1 || exit 1;
+
+endef
+

--- a/clear-containers.service.in
+++ b/clear-containers.service.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=Clear Containers Agent
+Documentation=https://github.com/clearcontainers/agent
+
+[Service]
+ExecStart=@bindir@/@ccagent@
+LimitNOFILE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/clear-containers.target
+++ b/clear-containers.target
@@ -1,0 +1,7 @@
+[Unit]
+Description=Clear Containers Agent Target
+Requires=basic.target
+Requires=clear-containers.service
+Conflicts=rescue.service rescue.target
+After=basic.target rescue.service rescue.target
+AllowIsolate=yes


### PR DESCRIPTION
This patch add systemd unit files.

* Change the binary name to cc-agent.
* Generates a systemd service file if systemd is installed.
* Install systemd service and target if systemd is installed.

The new systemd target can be used to boot using this agent.
Fixes: #11 
Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>