### PR TITLE
agent: End the agent in case of DESTROYPOD command

### DIFF
--- a/syscall.go
+++ b/syscall.go
@@ -105,7 +105,7 @@ func mountContainerRootFs(containerID, image, rootFs string) (string, error) {
 		return "", err
 	}
 
-	source := filepath.Join(mountShareDirDest, containerID)
+	source := filepath.Join(mountShareDirDest, image)
 	if err := bindMount(source, dest, false); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
We want to behave the same way hyperstart agent was behaving, that
is terminate in case a DESTROYPOD command is invoked.