### PR TITLE
agent: Change MTU type from string to integer

### DIFF
--- a/api/commands.go
+++ b/api/commands.go
@@ -75,7 +75,7 @@ type IPAddress struct {
 type NetIface struct {
 	Name        string      `json:"newDeviceName"`
 	IPAddresses []IPAddress `json:"ipAddresses"`
-	MTU         string      `json:"mtu"`
+	MTU         int         `json:"mtu"`
 	HwAddr      string      `json:"macAddr"`
 }
 


### PR DESCRIPTION
Hyperstart agent expects to receive an integer regarding the MTU
parameter. In order to be identical, we want this parameter to be
an integer instead of a string.

Fixes #34