### PR TITLE
service: Improve system service file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,12 @@ $(TARGET): $(SOURCES) Makefile $(GENERATED_FILES)
 install:
 	install -D $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
 ifeq ($(HAVE_SYSTEMD),yes)
+	@echo "Installing systemd unit files..."
 	$(foreach f,$(UNIT_FILES),$(call INSTALL_FILE,$f,$(UNIT_DIR)))
 endif
 
 $(GENERATED_FILES): %: %.in Makefile
+	@echo "Generating file: $@"
 	@mkdir -p `dirname $@`
 	$(QUIET_GEN)sed \
 		-e 's|[@]bindir[@]|$(BINDIR)|g' \

--- a/clear-containers.service.in
+++ b/clear-containers.service.in
@@ -1,10 +1,12 @@
 [Unit]
 Description=Clear Containers Agent
 Documentation=https://github.com/clearcontainers/agent
+Wants=clear-containers.target
 
 [Service]
+StandardOutput=tty
+Type=simple
 ExecStart=@bindir@/@ccagent@
 LimitNOFILE=infinity
-
-[Install]
-WantedBy=multi-user.target
+ExecStop=/bin/sync ; /usr/bin/systemctl --force poweroff
+FailureAction=poweroff


### PR DESCRIPTION
- Use StandardOutput to get proxy logs
- The service wants clear-containers.target
- Make explicit type=simple
- The agent is not wanted by mutil-user.target
- Shut down computer if  on ExecStop and FailureAction
- Sync disk after agent finish

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>