### PR TITLE
agent: Implement devicemapper support

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -881,7 +881,7 @@ func newContainerCb(pod *pod, data []byte) error {
 		return fmt.Errorf("Container %s already exists, impossible to create", payload.ID)
 	}
 
-	absoluteRootFs, err := mountContainerRootFs(payload.ID, payload.Image, payload.RootFs)
+	absoluteRootFs, err := mountContainerRootFs(payload.ID, payload.Image, payload.RootFs, payload.FsType)
 	if err != nil {
 		return err
 	}

--- a/api/commands.go
+++ b/api/commands.go
@@ -149,6 +149,7 @@ type NewContainer struct {
 	ID      string  `json:"id"`
 	RootFs  string  `json:"rootfs"`
 	Image   string  `json:"image"`
+	FsType  string  `json:"fstype,omitempty"`
 	Fsmap   []Fsmap `json:"fsmap"`
 	Process Process `json:"process"`
 }


### PR DESCRIPTION
In case fstype is given through the argument list provided for a
newcontainer command, we have to handle the mount of the container
rootfs differently. This means we have to rely on the given block
device to mount it at the expected location.

Fixes #50