### PR TITLE
version: Show the agent version in startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+# This is the version string used when it isn't possible to do a git describe,
+# which happens with a git-archive tarball for instance. A '+' is appended to
+# the version string to mean that it's a development version eg. 3.0.0+ means
+# somewhere between 3.0.0 and 3.0.1.
+#
+# The version should be bumped and the '+' sign removed just before tagging a
+# new release.
+# A '+' sign should be added in the commit just after tagging a new release.
+VERSION := 0.1.0-alpha.0+
 SOURCES := $(shell find . 2>&1 | grep -E '.*\.(c|h|go)$$')
 
 TARGET = cc-agent
@@ -5,6 +14,15 @@ DESTDIR :=
 PREFIX := /usr
 BINDIR := $(PREFIX)/bin
 
+DESCRIBE := $(shell git describe 2> /dev/null || true)
+DESCRIBE_DIRTY := $(if $(shell git status --porcelain --untracked-files=no 2> /dev/null),${DESCRIBE}-dirty,${DESCRIBE})
+GIT_COMMIT := $(shell git rev-parse HEAD 2>/dev/null)
+ifneq ($(GIT_COMMIT),)
+VERSION := $(VERSION)-$(GIT_COMMIT)
+endif
+ifneq ($(DESCRIBE_DIRTY),)
+VERSION := $(VERSION)$(DESCRIBE_DIRTY)
+endif
 
 HAVE_SYSTEMD := $(shell pkg-config --exists systemd 2>/dev/null && echo 'yes')
 
@@ -19,7 +37,7 @@ SED = sed
 
 .DEFAULT: $(TARGET)
 $(TARGET): $(SOURCES) Makefile $(GENERATED_FILES)
-	go build -o $@ .
+	go build -ldflags "-X main.Version=$(VERSION)" -o $@ .
 
 install:
 	install -D $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)

--- a/agent.go
+++ b/agent.go
@@ -159,7 +159,11 @@ func init() {
 	}
 }
 
+// Version is the agent version. This variable is populated at build time.
+var Version = "unknown"
+
 func main() {
+	agentLog.Infof("Agent version: %s", Version)
 	// Initialiaze wait group waiting for loops to be terminated
 	var wgLoops sync.WaitGroup
 	wgLoops.Add(1)


### PR DESCRIPTION
This patch adds a message to show the agent version
at startup, this will be useful for debugging.

Fixes: #52

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>