### PR TITLE
channels: Stat /sys/class/virtio-ports/*/name before reading it

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -396,6 +396,15 @@ func findVirtualSerialPath(serialName string) (string, error) {
 
 	for _, port := range ports {
 		path := filepath.Join(virtIOPath, port, "name")
+		if _, err := os.Stat(path); err != nil {
+			if os.IsNotExist(err) {
+				agentLog.Debugf("Skip parsing of %s as it does not exist", path)
+				continue
+			}
+
+			return "", err
+		}
+
 		content, err := ioutil.ReadFile(path)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
We don't want to end up getting an error because we tried to read a
non existing file. Indeed, we want to scan every entry inside the
path /sys/class/virtio-ports/, without throwing an error because
on of those entries does not have a file named "name". In that
case, we just want to skip it.

Fixes #58