### PR TITLE
agent: Kill only init process if specified this way

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1036,7 +1036,8 @@ func killContainerCb(pod *pod, data []byte) error {
 		return fmt.Errorf("Container %s not found, impossible to signal", payload.ID)
 	}
 
-	if err := pod.containers[payload.ID].container.Signal(payload.Signal, true); err != nil {
+	// Use AllProcesses to make sure we carry forward the flag passed by the runtime.
+	if err := pod.containers[payload.ID].container.Signal(payload.Signal, payload.AllProcesses); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
In case we were running CRI-O testing inside Semaphore, because the
system is kind of slow, the redis container process takes some time
to really start. Because we were issuing a kill signal right after
the start returned (does not mean the container's process finished
to start), and at the same time we were trying to kill all processes
related to the init process, this was hanging. Indeed, we should not
try to kill all processes until the init one is properly running.

This patch relies on AllProcesses flag provided in the "killcontainer"
payload, instead of hardcoding this value to "true". Indeed, the CRI-O
tests explicitely ask for a kill without the --all falg enabled. This
simple change allows our agent to get CRI-O testing passing properly
on Semaphore CI.

Fixes #61