### PR TITLE
tests: Initial unit tests

### DIFF
--- a/.ci/go-lint.sh
+++ b/.ci/go-lint.sh
@@ -1,0 +1,48 @@
+# Copyright (c) 2017 Intel Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#!/bin/bash
+
+set -e
+
+if [ ! $(command -v gometalinter) ]
+then
+	go get github.com/alecthomas/gometalinter
+	gometalinter --install --vendor
+fi
+
+linter_args="--tests --vendor --vendored-linters --exclude=vendor"
+
+# When running the linters in a CI environment we need to disable them all
+# by default and then explicitly enable the ones we are care about. This is
+# necessary since *if* gometalinter adds a new linter, that linter may cause
+# the CI build to fail when it really shouldn't. However, when this script is
+# run locally, all linters should be run to allow the developer to review any
+# failures (and potentially decide whether we need to explicitly enable a new
+# linter in the CI).
+if [ "$CI" = true ]; then
+	linter_args+=" --disable-all"
+fi
+
+linter_args+=" --enable=misspell"
+linter_args+=" --enable=vet"
+linter_args+=" --enable=ineffassign"
+linter_args+=" --enable=gofmt"
+linter_args+=" --enable=gocyclo"
+linter_args+=" --cyclo-over=15"
+linter_args+=" --enable=golint"
+linter_args+=" --deadline=600s"
+
+eval gometalinter "${linter_args}" ./...

--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+
+set -x
+script_dir=$(cd `dirname $0`; pwd)
+root_dir=`dirname $script_dir`
+
+test_packages=('.')
+go_test_flags="-v -race -timeout 2s"
+
+echo Running go test on packages "'$test_packages'" with flags "'$go_test_flags'"
+
+function test_html_coverage
+{
+	test_coverage
+	go tool cover -html=profile.cov
+	rm -f profile.cov
+}
+
+function test_coverage
+{
+	echo "mode: atomic" > profile.cov
+
+	for pkg in ${test_packages[@]}; do
+		fields=(${pkg//;/ })
+		pkg_name=${fields[0]}
+		pkg_cover=${fields[1]}
+		go test $go_test_flags -covermode=atomic -coverprofile=profile_tmp.cov -coverpkg $pkg_cover $pkg_name
+		[ -f profile_tmp.cov ] && tail -n +2 profile_tmp.cov >> profile.cov;
+		rm -f profile_tmp.cov
+	done
+}
+
+function test_local
+{
+	for pkg in ${test_packages[@]}; do
+		fields=(${pkg//;/ })
+		pkg_name=${fields[0]}
+		packages="$packages $pkg_name"
+	done
+
+	go test $go_test_flags $packages
+}
+
+if [ "$1" = "html-coverage" ]; then
+	test_html_coverage
+elif [ "$CI" = "true" ]; then
+	test_coverage
+else
+	test_local
+fi

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -22,6 +22,10 @@ set -x
 test_repo="github.com/clearcontainers/tests"
 test_repo_dir="${GOPATH}/src/${test_repo}"
 
+cidir=$(dirname "$0")
+
+bash -c "${cidir}/go-test.sh"
+
 # Execute the tests under `clearcontainers/tests` repository.
 pushd "${test_repo_dir}"
 sudo -E PATH=$PATH bash -c "make check"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -24,7 +24,7 @@ test_repo_dir="${GOPATH}/src/${test_repo}"
 
 cidir=$(dirname "$0")
 
-bash -c "${cidir}/go-test.sh"
+sudo -E PATH=$PATH bash -c  "make check"
 
 # Execute the tests under `clearcontainers/tests` repository.
 pushd "${test_repo_dir}"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 # A '+' sign should be added in the commit just after tagging a new release.
 VERSION := 0.1.0-alpha.0+
 SOURCES := $(shell find . 2>&1 | grep -E '.*\.(c|h|go)$$')
+MKDIR = $(dir $(lastword $(MAKEFILE_LIST)))
 
 TARGET = cc-agent
 DESTDIR :=
@@ -56,6 +57,10 @@ $(GENERATED_FILES): %: %.in Makefile
 dist:
 	git archive --format=tar --prefix=clear-containers-agent-$(VERSION)/ \
 		HEAD | xz -c > clear-containers-agent-$(VERSION).tar.xz
+
+check:
+	bash -c "$(MKDIR)/.ci/go-lint.sh"
+	bash -c "$(MKDIR)/.ci/go-test.sh"
 
 clean:
 	rm -f $(TARGET) $(GENERATED_FILES)

--- a/agent.go
+++ b/agent.go
@@ -31,12 +31,12 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/sirupsen/logrus"
 	hyper "github.com/clearcontainers/agent/api"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	_ "github.com/opencontainers/runc/libcontainer/nsenter"
 	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -120,15 +120,15 @@ type container struct {
 }
 
 type pod struct {
-	id           string
-	running      bool
-	containers   map[string]*container
-	ctl          *os.File
-	tty          *os.File
-	stdinList    map[uint64]*os.File
-	network      hyper.Network
-	stdinLock    sync.Mutex
-	ttyLock      sync.Mutex
+	id         string
+	running    bool
+	containers map[string]*container
+	ctl        *os.File
+	tty        *os.File
+	stdinList  map[uint64]*os.File
+	network    hyper.Network
+	stdinLock  sync.Mutex
+	ttyLock    sync.Mutex
 }
 
 type cmdCb func(*pod, []byte) error
@@ -170,9 +170,9 @@ func main() {
 
 	// Initialize unique pod structure
 	pod := &pod{
-		containers:   make(map[string]*container),
-		running:      false,
-		stdinList:    make(map[uint64]*os.File),
+		containers: make(map[string]*container),
+		running:    false,
+		stdinList:  make(map[uint64]*os.File),
 	}
 
 	// Open serial ports and write on both CTL and TTY channels

--- a/agent_test.go
+++ b/agent_test.go
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+const testDisabledAsNonRoot = "Test disabled as requires root privileges"
+
+// package variables set in TestMain
+var testDir = ""
+
+func TestMain(m *testing.M) {
+	var err error
+	testDir, err = ioutil.TempDir("", "cc-agent-tmp-")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(testDir)
+
+	ret := m.Run()
+	os.Exit(ret)
+
+}

--- a/api/commands.go
+++ b/api/commands.go
@@ -182,7 +182,7 @@ type Winsize struct {
 // CmdToString translates a command into its corresponding string.
 func CmdToString(cmd HyperCmd) string {
 	strCmd, exist := stringCmdList[cmd]
-	if exist == false {
+	if !exist {
 		return ""
 	}
 

--- a/syscall_test.go
+++ b/syscall_test.go
@@ -1,0 +1,144 @@
+//
+// Copyright 2015 The rkt Authors
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestBindMountInvalidSourceSymlink(t *testing.T) {
+	source := filepath.Join(testDir, "fooFile")
+	os.Remove(source)
+
+	err := bindMount(source, "", true)
+	if err == nil {
+		t.Fatal()
+	}
+}
+
+func TestBindMountFailingMount(t *testing.T) {
+	source := filepath.Join(testDir, "fooLink")
+	fakeSource := filepath.Join(testDir, "fooFile")
+	os.Remove(source)
+	os.Remove(fakeSource)
+
+	_, err := os.OpenFile(fakeSource, os.O_CREATE, mountPerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Symlink(fakeSource, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = bindMount(source, "", true)
+	if err == nil {
+		t.Fatal()
+	}
+}
+
+func TestBindMountSuccessful(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip(testDisabledAsNonRoot)
+	}
+
+	source := filepath.Join(testDir, "fooDirSrc")
+	dest := filepath.Join(testDir, "fooDirDest")
+	syscall.Unmount(dest, 0)
+	os.Remove(source)
+	os.Remove(dest)
+
+	err := os.MkdirAll(source, mountPerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.MkdirAll(dest, mountPerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = bindMount(source, dest, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	syscall.Unmount(dest, 0)
+}
+
+func TestEnsureDestinationExistsNonExistingSource(t *testing.T) {
+	err := ensureDestinationExists("", "", "")
+	if err == nil {
+		t.Fatal()
+	}
+}
+
+func TestEnsureDestinationExistsWrongParentDir(t *testing.T) {
+	source := filepath.Join(testDir, "fooFile")
+	dest := filepath.Join(source, "fooDest")
+	os.Remove(source)
+	os.Remove(dest)
+
+	_, err := os.OpenFile(source, os.O_CREATE, mountPerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ensureDestinationExists(source, dest, "")
+	if err == nil {
+		t.Fatal()
+	}
+}
+
+func TestEnsureDestinationExistsSuccessfulSrcDir(t *testing.T) {
+	source := filepath.Join(testDir, "fooDirSrc")
+	dest := filepath.Join(testDir, "fooDirDest")
+	os.Remove(source)
+	os.Remove(dest)
+
+	err := os.MkdirAll(source, mountPerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ensureDestinationExists(source, dest, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureDestinationExistsSuccessfulSrcFile(t *testing.T) {
+	source := filepath.Join(testDir, "fooDirSrc")
+	dest := filepath.Join(testDir, "fooDirDest")
+	os.Remove(source)
+	os.Remove(dest)
+
+	_, err := os.OpenFile(source, os.O_CREATE, mountPerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ensureDestinationExists(source, dest, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestFileCopy(t *testing.T) {
+
+	//Create Tempfile to tests
+	tmpfile, err := ioutil.TempFile("", "agent-unit-test")
+	if err != nil {
+		t.Fatal("expected an error: Failed to create TempFile")
+	}
+	defer os.Remove(tmpfile.Name())
+
+	type args struct {
+		srcPath string
+		dstPath string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"Source/destination paths are empty",
+			args{srcPath: "", dstPath: ""}, true},
+		{"Source path is empty",
+			args{srcPath: "", dstPath: "./file"}, true},
+		{"Destination path is empty",
+			args{srcPath: "./file", dstPath: ""}, true},
+		{"Source file does not exist",
+			args{srcPath: "./f/f/false", dstPath: "./d"}, true},
+		{"Destination path does not exist",
+			args{srcPath: tmpfile.Name(), dstPath: tmpfile.Name() + "/non-existing/dest"}, true},
+		{"Successful File Copy",
+			args{srcPath: tmpfile.Name(), dstPath: tmpfile.Name() + "-dest"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := fileCopy(tt.args.srcPath, tt.args.dstPath); (err != nil) != tt.wantErr {
+				t.Errorf("fileCopy() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			os.RemoveAll(tt.args.dstPath)
+		})
+	}
+}


### PR DESCRIPTION
 - Add initial utils.go
 - Add .ci/go-test.go for CI
- Add .ci/go-lint to run gometalinter
- Add make check target to run go-test.sh and go-lint.sh

Fixes: #21

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>