### PR TITLE
Add  timestamp to agent commands

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -161,7 +161,7 @@ func init() {
 		runtime.LockOSThread()
 		factory, _ := libcontainer.New("")
 		if err := factory.StartInitialization(); err != nil {
-			agentLog.Infof("init went wrong: %v", err)
+			agentLog.Errorf("init went wrong: %v", err)
 		}
 		panic("--this line should have never been executed, congratulations--")
 	}
@@ -230,7 +230,7 @@ func (p *pod) controlLoop(wg *sync.WaitGroup) {
 				continue
 			}
 
-			agentLog.Infof("Read on ctl channel failed: %v", err)
+			agentLog.Errorf("Read on ctl channel failed: %v", err)
 			break
 		}
 
@@ -707,7 +707,7 @@ func (p *pod) runContainerProcess(cid, pid string, terminal bool, started chan e
 
 	processState, err := p.containers[cid].processes[pid].process.Wait()
 	if err != nil {
-		agentLog.Infof("Wait for process %s failed: %v", pid, err)
+		agentLog.Errorf("Wait for process %s failed: %v", pid, err)
 	}
 
 	// Close pipes to terminate routeOutput() go routines.

--- a/agent_test.go
+++ b/agent_test.go
@@ -20,6 +20,9 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	_ "github.com/opencontainers/runc/libcontainer/nsenter"
+	"github.com/sirupsen/logrus"
 )
 
 const testDisabledAsNonRoot = "Test disabled as requires root privileges"
@@ -38,4 +41,115 @@ func TestMain(m *testing.M) {
 	ret := m.Run()
 	os.Exit(ret)
 
+}
+
+func TestParseCmdlineOption(t *testing.T) {
+	type args struct {
+		option string
+	}
+
+	tests := []struct {
+		name      string
+		args      args
+		wantErr   bool
+		wantLevel logrus.Level
+	}{
+		{"Empty cmdline",
+			args{""}, false, defaultLogLevel},
+		{"Log config info",
+			args{"agent.log=info"}, false, logrus.InfoLevel},
+		{"Log config debug",
+			args{"agent.log=debug"}, false, logrus.DebugLevel},
+		{"Log config warn",
+			args{"agent.log=warn"}, false, logrus.WarnLevel},
+		{"Log config empty",
+			args{"agent.log="}, true, defaultLogLevel},
+		{"Invalid log config",
+			args{"agent.log=ino"}, true, defaultLogLevel},
+		{"Unknown option",
+			args{"agent.logx=ino"}, true, defaultLogLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var config agentConfig
+			config.logLevel = defaultLogLevel
+
+			if err := config.parseCmdlineOption(tt.args.option); (err != nil) != tt.wantErr {
+				t.Errorf("parseCmdlineOption(%s) error = %v, wantErr %v",
+					tt.args.option, err, tt.wantErr)
+			}
+			if config.logLevel != tt.wantLevel {
+				t.Errorf("parseCmdlineOption(%s) config.logLevel = %s, wanted %s",
+					tt.args.option, config.logLevel, tt.wantLevel)
+
+			}
+		})
+	}
+}
+
+func createTmpfile(prefix string, content string) (string, error) {
+
+	tmpfile, err := ioutil.TempFile(testDir, prefix)
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := tmpfile.WriteString(content); err != nil {
+		return "", err
+	}
+
+	if err := tmpfile.Close(); err != nil {
+		return "", err
+	}
+
+	tmpfile.Sync()
+	return tmpfile.Name(), nil
+}
+
+func TestAgentConfigGetConfig(t *testing.T) {
+
+	nonExitingConfig := "/tmp/non-existhing-config-file"
+	os.RemoveAll(nonExitingConfig)
+
+	debugConfigFile, err := createTmpfile("debug-config", "init=systemd agent.log=debug")
+	if err != nil {
+		t.Fatalf("Failed to create debugConfigFile %v", err)
+	}
+	defer os.Remove(debugConfigFile)
+
+	type fields struct {
+		logLevel logrus.Level
+	}
+	type args struct {
+		cmdLineFile string
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		wantErr   bool
+		wantLevel logrus.Level
+	}{
+		{"Empty cmdLineFile",
+			fields{logrus.InfoLevel}, args{""}, true, logrus.InfoLevel},
+		{"Non-existing cmdLineFile",
+			fields{logrus.InfoLevel}, args{nonExitingConfig}, true, logrus.InfoLevel},
+		{"Debug config",
+			fields{logrus.InfoLevel}, args{debugConfigFile}, false, logrus.DebugLevel},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &agentConfig{
+				logLevel: tt.fields.logLevel,
+			}
+			err := c.getConfig(tt.args.cmdLineFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("agentConfig.getConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if c.logLevel != tt.wantLevel {
+				t.Errorf("agentConfig.Level = %s, wantLevel %s", c.logLevel, tt.wantLevel)
+			}
+		})
+	}
 }

--- a/time.go
+++ b/time.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package main
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+const agentStartedEvent = "agent_started"
+
+//Event that will be reported for time tracing
+type eventTime struct {
+	Event string
+	Time  unix.Timespec
+}
+
+// Get eventTime based CLOCK_MONOTONIC_RAW clock
+func newEventTime(event string) (eventTime, error) {
+	var ts unix.Timespec
+
+	if event == "" {
+		return eventTime{Event: "error", Time: ts}, fmt.Errorf("event cannot be empty")
+	}
+
+	if err := unix.ClockGettime(unix.CLOCK_MONOTONIC_RAW, &ts); err != nil {
+		return eventTime{}, err
+	}
+	return eventTime{Event: event, Time: ts}, nil
+}
+
+func (e eventTime) String() string {
+	return fmt.Sprintf("%s %d.%d", e.Event, e.Time.Sec, e.Time.Nsec)
+}

--- a/time_test.go
+++ b/time_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestNewEventTime(t *testing.T) {
+	type args struct {
+		event string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"Empty event name", args{""}, true},
+		{"Non-empty event name", args{"event"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newEventTime(tt.args.event)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("newEventTime() = %s, error = %v, wantErr %v", got, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEventTimeString(t *testing.T) {
+	type fields struct {
+		event string
+		time  unix.Timespec
+	}
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		{"Check event name", fields{"event", unix.Timespec{}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := eventTime{
+				Event: tt.fields.event,
+				Time:  tt.fields.time,
+			}
+			if got := e.String(); !strings.Contains(got, tt.fields.event) {
+				t.Errorf("eventTime.String() = \"%s\",  want it Contains = \"%s\"", got, tt.fields.event)
+			}
+			fmt.Println(e)
+		})
+	}
+}


### PR DESCRIPTION

- Agent now can get log level configuration from cmdline.
- Changed logrus time format to : `TimestampFormat: time.RFC3339Nano` to get nanoseconds precision.
- Start and end of commands is logged with the message:   `{event}_start` or  `{event}_end`
- An special case is logged `agent_started seconds.nanoseconds` this get uptime with good clock precision.  
- Logrus format is JSON for easy parsing 