### PR TITLE
CI: Remove user as project approver

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -35,7 +35,6 @@ groups:
     users:
       - amshinde
       - devimc
-      - dlespiau
       - grahamwhaley
       - mcastelino
       - sameo

--- a/OWNERS
+++ b/OWNERS
@@ -4,7 +4,6 @@ reviewers:
 approvers:
 - amshinde
 - devimc
-- dlespiau
 - grahamwhaley
 - mcastelino
 - sameo


### PR DESCRIPTION
Remove user dlespiau as a project approver as he is no longer a core
maintainer.

Fixes #77.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>