### PR TITLE
agent: run containers as non-root user

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -787,10 +787,15 @@ func (p *pod) buildProcess(hyperProcess hyper.Process) (*process, error) {
 		envList = append(envList, fmt.Sprintf("%s=%s", env.Env, env.Value))
 	}
 
+	// we can specify the user and the group separated by :
+	user := fmt.Sprintf("%s:%s", hyperProcess.User, hyperProcess.Group)
+
 	libContProcess := libcontainer.Process{
-		Cwd:  hyperProcess.Workdir,
-		Args: hyperProcess.Args,
-		Env:  envList,
+		Cwd:              hyperProcess.Workdir,
+		Args:             hyperProcess.Args,
+		Env:              envList,
+		User:             user,
+		AdditionalGroups: hyperProcess.AdditionalGroups,
 	}
 
 	proc := &process{


### PR DESCRIPTION
this patch adds support to run containers as non-root user

Fixes #83
Fixes https://github.com/clearcontainers/runtime/issues/386

Signed-off-by: Julio Montes <julio.montes@intel.com>