### PR TITLE
agent: Run ci with race-enabled agent binary

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -31,6 +31,8 @@ export test_repo_dir="${GOPATH}/src/${test_repo}"
 export runtime_repo="github.com/clearcontainers/runtime"
 export runtime_repo_dir="${GOPATH}/src/${runtime_repo}"
 
+export RACE_DETECTION=true
+
 # Clone Tests repository.
 go get "$test_repo"
 # Fixme: Remove after https://github.com/clearcontainers/runtime/pull/353

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,12 @@ SED = sed
 
 .DEFAULT: $(TARGET)
 $(TARGET): $(SOURCES) Makefile $(GENERATED_FILES)
-	go build -ldflags "-X main.Version=$(VERSION_COMMIT)" -o $@ .
+	@build_flags="" ; \
+	if [ "$$RACE_DETECTION" = true ] ; then \
+		build_flags="-race" ; \
+		echo "Building with $$build_flags" ; \
+	fi ; \
+	go build $$build_flags -ldflags "-X main.Version=$(VERSION_COMMIT)" -o $@ .
 
 install:
 	install -D $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)


### PR DESCRIPTION
Allow make to generate a race enabled binary and use that
to run tests in CI. This will help in debugging any
race conditions while executing functional and
integration tests in CI.

Fixes #84

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>