### PR TITLE
Update 9p mount syscall so mmap is rw

### DIFF
--- a/syscall.go
+++ b/syscall.go
@@ -103,7 +103,8 @@ func mountShareDir(tag string) error {
 		return err
 	}
 
-	return syscall.Mount(tag, mountShareDirDest, type9pFs, syscall.MS_MGC_VAL|syscall.MS_NODEV, "trans=virtio")
+	return syscall.Mount(tag, mountShareDirDest, type9pFs, syscall.MS_MGC_VAL|syscall.MS_NODEV, "trans=virtio,version=9p2000.L,posixacl,cache=mmap")
+
 }
 
 func unmountShareDir() error {


### PR DESCRIPTION
By default the mmap command for 9p is read only

Reason: generic_file_readonly_mmap is used by 9pfs Kernel side client
code, in case there is no caching.

For the guest OS, we need to ensure:
1. CONFIG_9P_FSCACHE is enabled in the guest kernel
2. v9f2_file_mmap is used instead of generic_file_readonly_mmap

For 2, we want cache=fscache to enable writable mmaps. This patch
addresses this requirement.

Fixes #92.

Signed-off-by: Eric Ernst <eric.ernst@intel.com>