### PR TITLE
Revert "agent: update 9p mount syscall so mmap is rw"

### DIFF
--- a/syscall.go
+++ b/syscall.go
@@ -103,8 +103,7 @@ func mountShareDir(tag string) error {
 		return err
 	}
 
-	return syscall.Mount(tag, mountShareDirDest, type9pFs, syscall.MS_MGC_VAL|syscall.MS_NODEV, "trans=virtio,version=9p2000.L,posixacl,cache=mmap")
-
+	return syscall.Mount(tag, mountShareDirDest, type9pFs, syscall.MS_MGC_VAL|syscall.MS_NODEV, "trans=virtio")
 }
 
 func unmountShareDir() error {


### PR DESCRIPTION
This reverts commit ef75affbab846b099993779a72db0bf3396cd0be.

By introducing the 9p "fix", we now have the CI being very unstable.
It would worth to investigate this more, but for the time being, we
want to fix the CI reliability.

Fixes #99