### PR TITLE
agent: update 9p mount syscall so mmap is rw

### DIFF
--- a/syscall.go
+++ b/syscall.go
@@ -103,7 +103,8 @@ func mountShareDir(tag string) error {
 		return err
 	}
 
-	return syscall.Mount(tag, mountShareDirDest, type9pFs, syscall.MS_MGC_VAL|syscall.MS_NODEV, "trans=virtio")
+	return syscall.Mount(tag, mountShareDirDest, type9pFs, syscall.MS_MGC_VAL|syscall.MS_NODEV, "trans=virtio,version=9p2000.L,posixacl,cache=mmap")
+
 }
 
 func unmountShareDir() error {


### PR DESCRIPTION
By default the mmap command for 9p is read only

Reason: generic_file_readonly_mmap is used by 9pfs Kernel side client
code in case there is no caching.

Based on this, we should enable caching for our 9p mounts.
There are two verified options for this:
 1. cache=fscache
 2. cache=mmap

After running FIO tests (random and linear read/write i/o), I see mmap
providing slightly better performance, and it does not require any
additional kernel config options to be enabled.

Currently the value of cache=none (the default for mount). Enabling
caching gives performance that is on parity with no caching, and slight
improvements for random write IO.

Fixes #92.

Signed-off-by: Eric Ernst <eric.ernst@intel.com>