### PR TITLE
ci: Update apt repositories before attempting an install of a package

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -39,6 +39,9 @@ export RACE_DETECTION=true
 # Clone Tests repository.
 go get "$test_repo"
 
+# Update apt repositories
+sudo -E apt update
+
 # Install libudev-dev required for go-udev vendor dependency
 if [ "$ID" == fedora ]
 then


### PR DESCRIPTION
We should be updating apt repositories before attempting an install
of a package.

Fixes #108

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>