### PR TITLE
readme: Update build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[![Build Status](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/clear-containers-agent-azure-ubuntu-16-04/badge/icon)](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/clear-containers-agent-azure-ubuntu-16-04/)
-[![Build Status](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/clear-containers-agent-azure-ubuntu-17-04/badge/icon)](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/clear-containers-agent-azure-ubuntu-17-04/)
+[![Build Status](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/clear-containers-agent-azure-ubuntu-16-04-master/badge/icon)](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/clear-containers-agent-azure-ubuntu-16-04-master/)
+[![Build Status](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/clear-containers-agent-azure-ubuntu-17-04-master/badge/icon)](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/clear-containers-agent-azure-ubuntu-17-04-master/)
+[![Build Status](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/clear-containers-agent-fedora-26-master/badge/icon)](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/clear-containers-agent-fedora-26-master/)
 [![Go Report Card](https://goreportcard.com/badge/github.com/clearcontainers/agent)](https://goreportcard.com/report/github.com/clearcontainers/agent)
 [![Coverage Status](https://coveralls.io/repos/github/clearcontainers/agent/badge.svg?branch=master)](https://coveralls.io/github/clearcontainers/agent?branch=master)
 


### PR DESCRIPTION
This commit updates the build badges for Ubuntu 16.04 and 17.04
jenkins jobs since their names changed.
It also adds the build badge related to Fedora 26.

Fixes #116