### PR TITLE
Debug: Provide a way to enable a debug console to the VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ HAVE_SYSTEMD := $(shell pkg-config --exists systemd 2>/dev/null && echo 'yes')
 
 ifeq ($(HAVE_SYSTEMD),yes)
 UNIT_DIR := $(shell pkg-config --variable=systemdsystemunitdir systemd)
-UNIT_FILES = clear-containers.service
+UNIT_FILES = clear-containers.service clear-containers-debug.service
 GENERATED_FILES := $(UNIT_FILES)
-UNIT_FILES += clear-containers.target
+UNIT_FILES += clear-containers.target clear-containers-debug.target
 endif
 
 SED = sed

--- a/clear-containers-debug.service.in
+++ b/clear-containers-debug.service.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=Clear Container debug console
+
+[Service]
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+StandardInput=tty
+StandardOutput=tty
+PrivateDevices=yes
+Type=simple
+ExecStart=/usr/bin/bash

--- a/clear-containers-debug.target
+++ b/clear-containers-debug.target
@@ -1,0 +1,8 @@
+[Unit]
+Description=Clear Containers Agent Target
+Requires=basic.target
+Requires=clear-containers.service
+Wants=clear-containers-debug-console.service
+Conflicts=rescue.service rescue.target
+After=basic.target rescue.service rescue.target
+AllowIsolate=yes


### PR DESCRIPTION
Provide an additional unit file to enable a debug console.
Also provide an additional agent service file variant that
can be used to launch the VM in debug mode.

The console can be attached using

socat STATE_DIR_CONTAINER/console.sock -

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>