### PR TITLE
target: Add clr-power-tweaks add target depedency.

### DIFF
--- a/clear-containers.target
+++ b/clear-containers.target
@@ -2,6 +2,7 @@
 Description=Clear Containers Agent Target
 Requires=basic.target
 Requires=clear-containers.service
+Wants=clr-power.service
 Conflicts=rescue.service rescue.target
 After=basic.target rescue.service rescue.target
 AllowIsolate=yes


### PR DESCRIPTION
`clr-power-tweaks` is a service provided in Clear Linux to
tweak perfomance configuration at boot time.

This patch adds it as depedency.

Note that we 'Want' it so the clear containers target
wont fail in case the service is not present or fails.

Fixes: #126

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>