### PR TITLE
devices: Add extra field in fsmap to directly mount devices.

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1030,8 +1030,14 @@ func destroyPodCb(pod *pod, data []byte) error {
 
 func addMounts(config *configs.Config, fsmaps []hyper.Fsmap) error {
 	for _, fsmap := range fsmaps {
+
+		source := fsmap.Source
+		if !fsmap.AbsolutePath {
+			source = filepath.Join(mountShareDirDest, fsmap.Source)
+		}
+
 		newMount := &configs.Mount{
-			Source:      filepath.Join(mountShareDirDest, fsmap.Source),
+			Source:      source,
 			Destination: fsmap.Path,
 			Device:      "bind",
 			Flags:       syscall.MS_BIND | syscall.MS_REC,

--- a/api/commands.go
+++ b/api/commands.go
@@ -105,6 +105,7 @@ type EnvironmentVar struct {
 type Fsmap struct {
 	Source       string `json:"source"`
 	Path         string `json:"path"`
+	AbsolutePath bool   `json:"absolutePath"`
 	ReadOnly     bool   `json:"readOnly"`
 	DockerVolume bool   `json:"dockerVolume"`
 }


### PR DESCRIPTION
Entries in container fsmap are appended to the shared directory
and mounted. Add an extra field to support absolute mount paths.
This is needed for mounting block devices attached to the VM.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>