### PR TITLE
agent: re-scan pci bus to discover hidden devices

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -65,6 +65,8 @@ const (
 	logLevelFlag       = optionPrefix + "log"
 	defaultLogLevel    = logrus.InfoLevel
 	cannotGetTimeMsg   = "Failed to get time for event %s:%v"
+	pciBusRescanFile   = "/sys/bus/pci/rescan"
+	pciBusMode         = 0220
 )
 
 var capsList = []string{
@@ -1059,6 +1061,12 @@ func addMounts(config *configs.Config, fsmaps []hyper.Fsmap) error {
 
 func newContainerCb(pod *pod, data []byte) error {
 	var payload hyper.NewContainer
+
+	// re-scan PCI bus
+	// looking for hidden devices
+	if err := ioutil.WriteFile(pciBusRescanFile, []byte("1"), pciBusMode); err != nil {
+		agentLog.WithError(err).Warnf("Could not rescan PCI bus")
+	}
 
 	if pod.running == false {
 		return fmt.Errorf("Pod not started, impossible to run a new container")


### PR DESCRIPTION
qemu <= 2.9 does not support ACPI pci hotplug in Q35 machines,
this means the linux kernel will not receive the order to
re-enumerate/re-scan the pci devices connected to the buses,
hence pci bus must be re-scanned manually looking for hidden devices

fixes #138

Signed-off-by: Julio Montes <julio.montes@intel.com>