### PR TITLE
agent-cli: Allow reconnection to the agent

### DIFF
--- a/hack/agent-cli/README.md
+++ b/hack/agent-cli/README.md
@@ -32,8 +32,10 @@ cc-agent
 
 From a different shell on the host (as root):
 ```
-# ./agent-cli run --ctl=/tmp/hyper.sock --tty=/tmp/tty.sock
+# ./agent-cli run --ctl=/tmp/hyper.sock --tty=/tmp/tty.sock --wait-for-ready
 ```
+
+Do not use the `--wait-for-ready` flag when the `agent-cli` is terminated or disconnected from the `CTL` and `TTY` sockets and the agent is still listening on those sockets. In this case, the agent will not send a `READY` message.
 
 ## Usage
 

--- a/hack/agent-cli/agent_cli.go
+++ b/hack/agent-cli/agent_cli.go
@@ -267,6 +267,7 @@ func monitorTtyOutLoop(h *hyperstart.Hyperstart, done chan<- bool) error {
 func mainLoop(c *cli.Context) error {
 	ctlSockPath := c.String("ctl")
 	ttySockPath := c.String("tty")
+	waitForReady := c.Bool("wait-for-ready")
 
 	if ctlSockPath == "" || ttySockPath == "" {
 		return fmt.Errorf("Missing socket path: please provide CTL and TTY socket paths")
@@ -279,8 +280,10 @@ func mainLoop(c *cli.Context) error {
 	}
 	defer h.CloseSockets()
 
-	if err := h.WaitForReady(); err != nil {
-		return err
+	if waitForReady {
+		if err := h.WaitForReady(); err != nil {
+			return err
+		}
 	}
 
 	done := make(chan bool)
@@ -313,6 +316,10 @@ func main() {
 					Name:  "tty",
 					Value: "",
 					Usage: "the TTY socket path",
+				},
+				cli.BoolFlag{
+					Name:  "wait-for-ready",
+					Usage: "boolean flag to wait for READY message first",
 				},
 			},
 			Action: func(context *cli.Context) error {


### PR DESCRIPTION
Because the agent sends a READY message the first time a connection is established, there is no way to reconnect without killing/restarting the agent. In order to workaround this, a new flag is added to the agent CLI so that we can make a difference between those two cases.

Fixes #150