### PR TITLE
.ci: Set CI env variable from run.sh

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -19,13 +19,15 @@
 set -e
 set -x
 
+export CI=true
+
 test_repo="github.com/clearcontainers/tests"
 test_repo_dir="${GOPATH}/src/${test_repo}"
 
 cidir=$(dirname "$0")
 
 # Run unit testing
-sudo -E PATH=$PATH CI=$CI bash -c "make check"
+sudo -E PATH=$PATH bash -c "make check"
 
 # Execute the tests under `clearcontainers/tests` repository.
 pushd "${test_repo_dir}"


### PR DESCRIPTION
Force CI=true from run.sh since this script is only called in a CI
context.

Fixes #152