### PR TITLE
destroy: Change DESTROYPOD behavior not to exit

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -306,10 +306,6 @@ func (p *pod) controlLoop(wg *sync.WaitGroup) {
 			fieldLogger.WithError(err).Info("reply send failed")
 			break
 		}
-
-		if cmd == hyper.DestroyPodCmd {
-			break
-		}
 	}
 
 out:


### PR DESCRIPTION
This patch is simple but it modifies the complete behavior of the
DESTROYPOD command since it won't cause the agent process to exit
and it won't cause the VM to exit subsequently.

Indeed, we expect the runtime to be responsible for destroying the
VM, and not the agent itself. Moreover, this behavior could allow
the support for a restart of the pod without restarting the VM.
The future will tell us if that's something we need to implement.

Fixes #159