### PR TITLE
mount: Do not mount sysfs as readonly

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -38,7 +38,6 @@ import (
 	_ "github.com/opencontainers/runc/libcontainer/nsenter"
 	"github.com/opencontainers/runc/libcontainer/utils"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -1173,7 +1172,7 @@ func newContainerCb(pod *pod, data []byte) error {
 				Source:      "sysfs",
 				Destination: "/sys",
 				Device:      "sysfs",
-				Flags:       defaultMountFlags | unix.MS_RDONLY,
+				Flags:       defaultMountFlags,
 			},
 		},
 


### PR DESCRIPTION
Sysfs needs to be read-write.
Fixes #163

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>