### PR TITLE
security: Enable no-new-privs by default

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1192,7 +1192,8 @@ func newContainerCb(pod *pod, data []byte) error {
 			},
 		},
 
-		NoNewKeyring: true,
+		NoNewKeyring:    true,
+		NoNewPrivileges: true,
 	}
 
 	// Populate config.Mounts with additional mounts provided through


### PR DESCRIPTION
    security: Enable no-new-privs by default
    
    By default, we don't want the containers spawned by our agent to be
    able to gain additional privileges.
    
    Fixes #165
    
    Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>