### PR TITLE
sync: Flush all caches when destroying the pod

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1063,6 +1063,10 @@ func destroyPodCb(pod *pod, data []byte) error {
 	pod.stdinList = make(map[uint64]stdinInfo)
 	pod.network = hyper.Network{}
 
+	// Synchronize the caches on the system. This is needed to ensure
+	// there is no pending transactions left before the VM is shut down.
+	syscall.Sync()
+
 	return nil
 }
 


### PR DESCRIPTION
    sync: Flush all caches when destroying the pod
    
    When DESTROYPOD command is called, this means the VM is going to be
    shut down right after. Because we don't want to shut down the VM with
    some pending buffers, this patch calls into sync() system call to make
    sure all buffers are flushed.
    
    From sync() man page:
    "According to the standard specification (e.g., POSIX.1-2001), sync()
     schedules the writes, but may return before the actual writing is
     done. However Linux waits for I/O completions, and thus sync() or
     syncfs() provide the same guarantees as fsync called on every file
     in the system or filesystem respectively."
    
    This will ensure that sync() will block until all buffers are properly
    flushed.
    
    Fixes #168
    
    Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>