### PR TITLE
dev: Bind mount /dev/vfio

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1230,6 +1230,12 @@ func newContainerCb(pod *pod, data []byte) error {
 				Device:      "sysfs",
 				Flags:       defaultMountFlags,
 			},
+			{
+				Source:      "/dev/vfio",
+				Destination: "/dev/vfio",
+				Device:      "bind",
+				Flags:       syscall.MS_BIND | syscall.MS_REC,
+			},
 		},
 
 		NoNewKeyring:    true,


### PR DESCRIPTION
We need the agent to detect devices that have been created under
/dev and mount them for the container to have accesss to device nodes.

In the meantime, bind mount just /dev/vfio to support vfio
and assigning devices to vfio driver. This will be removed once
complete support has been added.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>