### PR TITLE
Remove redundant "if" check

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -783,11 +783,7 @@ func setConsoleCarriageReturn(fd uintptr) error {
 
 	termios.Oflag |= syscall.ONLCR
 
-	if err := ioctl(fd, syscall.TCSETS, uintptr(unsafe.Pointer(&termios))); err != nil {
-		return err
-	}
-
-	return nil
+	return ioctl(fd, syscall.TCSETS, uintptr(unsafe.Pointer(&termios)))
 }
 
 // Executed as go routine to run and wait for the process.

--- a/syscall.go
+++ b/syscall.go
@@ -219,11 +219,7 @@ func unmountContainerRootFs(containerID, mountingPath string) error {
 		return err
 	}
 
-	if err := os.RemoveAll(containerPath); err != nil {
-		return err
-	}
-
-	return nil
+	return os.RemoveAll(containerPath)
 }
 
 func ioctl(fd uintptr, flag, data uintptr) error {


### PR DESCRIPTION
The "if" check is redundant, return error directly instead.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>