### PR TITLE
agent: add CAP_SYS_ADMIN capability

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -135,6 +135,7 @@ var defaultCapsList = []string{
 	"CAP_MKNOD",
 	"CAP_AUDIT_WRITE",
 	"CAP_SETFCAP",
+	"CAP_SYS_ADMIN",
 }
 
 type agentConfig struct {


### PR DESCRIPTION
container must be able to mount/umount block device, for this
reason CAP_SYS_ADMIN must be part of the default capabilities list

fixes #173

Signed-off-by: Julio Montes <julio.montes@intel.com>