### PR TITLE
Listen to udev "add" events to detect devices that have been added and bind mount these within pod's containers. 

### DIFF
--- a/api/commands.go
+++ b/api/commands.go
@@ -147,14 +147,25 @@ type StartPod struct {
 	ShareDir   string     `json:"shareDir"`
 }
 
+// SystemMountsInfo describes additional information for system mounts that the agent
+// needs to handle
+type SystemMountsInfo struct {
+	// Indicates if /dev has been passed as a bind mount for the host /dev
+	BindMountDev bool `json:"bindMountDev"`
+
+	// Size of /dev/shm assigned on the host.
+	DevShmSize int `json:"devShmSize"`
+}
+
 // NewContainer describes the format expected by a NEWCONTAINER command.
 type NewContainer struct {
-	ID      string  `json:"id"`
-	RootFs  string  `json:"rootfs"`
-	Image   string  `json:"image"`
-	FsType  string  `json:"fstype,omitempty"`
-	Fsmap   []Fsmap `json:"fsmap"`
-	Process Process `json:"process"`
+	ID               string           `json:"id"`
+	RootFs           string           `json:"rootfs"`
+	Image            string           `json:"image"`
+	FsType           string           `json:"fstype,omitempty"`
+	Fsmap            []Fsmap          `json:"fsmap"`
+	Process          Process          `json:"process"`
+	SystemMountsInfo SystemMountsInfo `json:"systemMountsInfo"`
 }
 
 // KillContainer describes the format expected by a KILLCONTAINER command.


### PR DESCRIPTION
From within a container, if a device is attached to a user driver, resulting in new device nodes being created under /dev, these are not visible from within a container. This is because /dev is mounted using tmpfs in a separate mount namespace. We need to continue using tmpfs, to restrict access to the initial set of devices available to the container. But we do need to provide a way for the container to access devices created later on based on a whitelist/blacklist.

This PR fixes this by watching for devices created and bind mounts these to each container's /dev so that the container is able to access the devices.