### PR TITLE
debug: Send errors on the control channel

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -332,7 +332,9 @@ func (p *pod) controlLoop(wg *sync.WaitGroup) {
 			reply = hyper.ErrorCmd
 		}
 
-		if response == nil {
+		if err != nil {
+			response = []byte(err.Error())
+		} else if response == nil {
 			response = []byte{}
 		}
 


### PR DESCRIPTION
We were always sending the response that was received on executing agent
callback function for a command, on the control channel.
In case of an error, this response is empty and hence the error is not
propogated to the proxy at all, resulting in an empty message sent to
the proxy in case of error.
Instead check for error case and send the error string on the control
channel. With this, we can finally see the errors occurring in the agent
in the proxy logs.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>