### PR TITLE
privileges: Add NoNewPrivileges in the api

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1241,7 +1241,7 @@ func newContainerCb(pod *pod, data []byte) error {
 		},
 
 		NoNewKeyring:    true,
-		NoNewPrivileges: true,
+		NoNewPrivileges: payload.Process.NoNewPrivileges,
 	}
 
 	// Populate config.Mounts with additional mounts provided through

--- a/api/commands.go
+++ b/api/commands.go
@@ -124,6 +124,7 @@ type Process struct {
 	Args             []string         `json:"args"`
 	Envs             []EnvironmentVar `json:"envs,omitempty"`
 	Workdir          string           `json:"workdir"`
+	NoNewPrivileges  bool             `json:"noNewPrivileges"`
 }
 
 // DecodedMessage describes messages going through CTL channel.


### PR DESCRIPTION
We were defaulting the NoNewPrivileges flag to true.
Instead parse this from the payload and then pass it to libcontainer.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>