### PR TITLE
WIP: scsi: Add support to pass SCSI address for SCSI disks

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -526,7 +526,9 @@ func (p *pod) listenToUdevEvents(done chan struct{}) {
 		for d := range ch {
 			fieldLogger.WithFields(logrus.Fields{
 				"udev-path":  d.Syspath(),
+				"dev-path":   d.Devpath(),
 				"udev-event": d.Action(),
+				"event":      d,
 			}).Info("Received udev event")
 
 			// Ignore udev events for block devices, these are handled by another go-routine in waitForBlockDevice
@@ -1283,10 +1285,13 @@ func newContainerCb(pod *pod, data []byte) error {
 		return fmt.Errorf("Pod not started, impossible to run a new container")
 	}
 
+	agentLog.WithField("xxxData", data).Info("Data before parsing")
+
 	if err := json.Unmarshal(data, &payload); err != nil {
 		return err
 	}
 
+	agentLog.WithField("xxxpayload", payload).Info("Payload parsed")
 	if payload.Process.ID == "" {
 		payload.Process.ID = fmt.Sprintf("%d", payload.Process.Stdio)
 	}

--- a/agent.go
+++ b/agent.go
@@ -1295,7 +1295,7 @@ func newContainerCb(pod *pod, data []byte) error {
 		return fmt.Errorf("Container %s already exists, impossible to create", payload.ID)
 	}
 
-	absoluteRootFs, err := mountContainerRootFs(payload.ID, payload.Image, payload.RootFs, payload.FsType)
+	absoluteRootFs, err := mountContainerRootFs(payload.ID, payload.Image, payload.RootFs, payload.FsType, payload.SCSIAddr)
 	if err != nil {
 		return err
 	}

--- a/api/commands.go
+++ b/api/commands.go
@@ -182,6 +182,9 @@ type NewContainer struct {
 	Fsmap            []Fsmap          `json:"fsmap"`
 	Process          Process          `json:"process"`
 	SystemMountsInfo SystemMountsInfo `json:"systemMountsInfo"`
+
+	// SCSI address in the format SCSI-Id:LUN
+	SCSIAddr string `json:"scsiAddr,omitempty"`
 }
 
 // KillContainer describes the format expected by a KILLCONTAINER command.

--- a/vendor/github.com/containers/virtcontainers/container.go
+++ b/vendor/github.com/containers/virtcontainers/container.go
@@ -520,10 +520,10 @@ func (c *Container) start() error {
 	}
 
 	if err = c.pod.agent.startContainer(*(c.pod), *c); err != nil {
-		c.Logger().WithError(err).Error("Failed to start container")
+		c.Logger().WithError(err).Error("Failedddddd to start container")
 
 		if err := c.stop(); err != nil {
-			c.Logger().WithError(err).Warn("Failed to stop container")
+			c.Logger().WithError(err).Warn("Failedddd to stop container")
 		}
 		return err
 	}


### PR DESCRIPTION
Add support for SCSI disk to be passed for container rootfs.
If SCSI address is provided, use that to get the SCSI disk name.
This eliminates the need to predict the drive name on the host side.
We do need to incur the cost of scanning SCSI bus.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>