### PR TITLE
agent: add libudev as dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ GENERATED_FILES := $(UNIT_FILES)
 UNIT_FILES += clear-containers.target
 endif
 
+HAVE_LIBUDEV := $(shell pkg-config --exists libudev 2>/dev/null || echo 'no')
+ifeq ($(HAVE_LIBUDEV),no)
+$(error "Install libudev devel")
+endif
+
 SED = sed
 
 .DEFAULT: $(TARGET)


### PR DESCRIPTION
to build the agent libudev devel package must be installed,
this library is needed because now the agent supports udev
events.

fixes #191

Signed-off-by: Julio Montes <julio.montes@intel.com>