### PR TITLE
agent: Fix sync issues with exit code and stdout of a process

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1031,6 +1031,12 @@ func (p *pod) runContainerProcess(cid, pid string, terminal bool, started chan e
 		return err
 	}
 
+	// Make sure all output has been routed before to go further and
+	// return the exit code.
+	ctr.closeProcessStreams(pid)
+	ctr.closeProcessPipes(pid)
+	wgRouteOutput.Wait()
+
 	agentLog.WithField("exit-code", exitCode).Info("got wait exit code")
 
 	// Send empty message on tty channel to close the IO stream


### PR DESCRIPTION
The patch about subreaping introduced some bugs by removing some
code that was actually very important. This code relates to the
synchronization of the stdout coming from the process and its exit
code being returned before. In case the exit code was returned before
stdout was not forwarded to the shim since the connection had been
dropped.

This commit restores few lines of code ensuring all output has been
forwarded before to send the exit code.

Fixes #196

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>