### PR TITLE
CI: Don't require an issue for release PRs

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -56,6 +56,7 @@ checkcommits \
 	--need-sign-offs \
 	--body-length 72 \
 	--subject-length 75 \
+	--ignore-fixes-for-subsystem "release" \
 	--verbose
 
 pushd "${test_repo_dir}"


### PR DESCRIPTION
Change the `checkcommits` config to not require an issue for release
PRs.

Fixes #199.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>