### PR TITLE
agent: apply CPU constraints to containers

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1355,6 +1355,8 @@ func newContainerCb(pod *pod, data []byte) error {
 				MemorySwappiness: nil,
 				AllowAllDevices:  nil,
 				AllowedDevices:   configs.DefaultAllowedDevices,
+				CpuQuota:         payload.Constraints.CPUQuota,
+				CpuPeriod:        payload.Constraints.CPUPeriod,
 			},
 		},
 		Devices: configs.DefaultAutoCreatedDevices,

--- a/api/commands.go
+++ b/api/commands.go
@@ -173,6 +173,15 @@ type SystemMountsInfo struct {
 	DevShmSize int `json:"devShmSize"`
 }
 
+// Constraints describes the constraints for a container
+type Constraints struct {
+	// CPUQuota specifies the total amount of time in microseconds
+	CPUQuota int64
+
+	// CPUPeriod specifies a period of time in microseconds
+	CPUPeriod uint64
+}
+
 // NewContainer describes the format expected by a NEWCONTAINER command.
 type NewContainer struct {
 	ID               string           `json:"id"`
@@ -182,6 +191,7 @@ type NewContainer struct {
 	Fsmap            []Fsmap          `json:"fsmap"`
 	Process          Process          `json:"process"`
 	SystemMountsInfo SystemMountsInfo `json:"systemMountsInfo"`
+	Constraints      Constraints      `json:"constraints"`
 }
 
 // KillContainer describes the format expected by a KILLCONTAINER command.


### PR DESCRIPTION
this patch reads the CPU constrains from the ctl channel and apply them

fixes #203

Signed-off-by: Julio Montes <julio.montes@intel.com>