### PR TITLE
Add support for scsi

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1306,6 +1306,15 @@ func addMounts(config *configs.Config, fsmaps []hyper.Fsmap) error {
 	for _, fsmap := range fsmaps {
 
 		source := fsmap.Source
+		var err error
+
+		if fsmap.SCSIAddr != "" {
+			source, err = getSCSIDisk(fsmap.SCSIAddr)
+			if err != nil {
+				return err
+			}
+		}
+
 		if !fsmap.AbsolutePath {
 			source = filepath.Join(mountShareDirDest, fsmap.Source)
 		}

--- a/agent.go
+++ b/agent.go
@@ -1387,7 +1387,7 @@ func newContainerCb(pod *pod, data []byte) error {
 		return fmt.Errorf("Container %s already exists, impossible to create", payload.ID)
 	}
 
-	absoluteRootFs, err := mountContainerRootFs(payload.ID, payload.Image, payload.RootFs, payload.FsType)
+	absoluteRootFs, err := mountContainerRootFs(payload)
 	if err != nil {
 		return err
 	}

--- a/api/commands.go
+++ b/api/commands.go
@@ -192,6 +192,9 @@ type NewContainer struct {
 	Process          Process          `json:"process"`
 	SystemMountsInfo SystemMountsInfo `json:"systemMountsInfo"`
 	Constraints      Constraints      `json:"constraints"`
+
+	// SCSI address in the format SCSI-Id:LUN
+	SCSIAddr string `json:"scsiAddr,omitempty"`
 }
 
 // KillContainer describes the format expected by a KILLCONTAINER command.

--- a/api/commands.go
+++ b/api/commands.go
@@ -110,6 +110,11 @@ type Fsmap struct {
 	AbsolutePath bool   `json:"absolutePath"`
 	ReadOnly     bool   `json:"readOnly"`
 	DockerVolume bool   `json:"dockerVolume"`
+
+	// SCSIAddr is the SCSI address in the format SCSI-id:LUN.
+	// If SCSIAddr is provided, we use that to determine the device name to be mounted
+	// ignoring the Source field that is used for as the source location for mounting otherwise.
+	SCSIAddr string `json:"scsiAddr,omitempty"`
 }
 
 // Capabilities specify the capabilities to keep when executing the process inside the container.

--- a/syscall_test.go
+++ b/syscall_test.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -139,6 +140,101 @@ func TestEnsureDestinationExistsSuccessfulSrcFile(t *testing.T) {
 
 	err = ensureDestinationExists(source, dest, "")
 	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFindSCSIDisk(t *testing.T) {
+	scsiTestDir := filepath.Join(testDir, "testSCSIDir")
+	os.RemoveAll(scsiTestDir)
+
+	defer os.RemoveAll(scsiTestDir)
+
+	scsiDiskPrefix = scsiTestDir + "/0:0:"
+	scsiAddr := "1:1"
+
+	_, err := findSCSIDisk(scsiAddr)
+	if err == nil {
+		t.Fatal()
+	}
+
+	path := fmt.Sprintf("%s%s/device/block", scsiDiskPrefix, scsiAddr)
+	if err := os.MkdirAll(path, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := findSCSIDisk(scsiAddr); err == nil {
+		t.Fatal()
+	}
+
+	devFile := filepath.Join(path, "sda")
+
+	f, err := os.OpenFile(devFile, os.O_CREATE, mountPerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	diskName, err := findSCSIDisk(scsiAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diskName != "sda" {
+		t.Fatal()
+	}
+
+	devFile = filepath.Join(path, "sdb")
+
+	f, err = os.OpenFile(devFile, os.O_CREATE, mountPerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := findSCSIDisk(scsiAddr); err == nil {
+		t.Fatal()
+	}
+}
+
+func TestScanSCSIBus(t *testing.T) {
+	scsiHostPath = filepath.Join(testDir, "scsi_host")
+	os.RemoveAll(scsiHostPath)
+
+	defer os.RemoveAll(scsiHostPath)
+
+	scsiAddr := "1"
+
+	if err := scanSCSIBus(scsiAddr); err == nil {
+		t.Fatal()
+	}
+
+	if err := os.MkdirAll(scsiHostPath, mountPerm); err != nil {
+		t.Fatal(err)
+	}
+
+	scsiAddr = "1:1"
+	if err := scanSCSIBus(scsiAddr); err != nil {
+		t.Fatal(err)
+	}
+
+	host := filepath.Join(scsiHostPath, "host0")
+	if err := os.MkdirAll(host, mountPerm); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := scanSCSIBus(scsiAddr); err != nil {
+		t.Fatal()
+	}
+
+	scanPath := filepath.Join(host, "scan")
+	if _, err := os.Stat(scanPath); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Add support for SCSI disks to be passed for container rootfs and volumes.
If SCSI address is provided, use that to get the SCSI disk name.
This eliminates the need to predict the drive name of the block
device on the host side. We do need to incur the cost of scanning SCSI bus.