### PR TITLE
process: Fix the way output is handled after process termination

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -989,10 +989,10 @@ func (p *pod) runContainerProcess(cid, pid string, terminal bool, started chan e
 	ctr := p.getContainer(cid)
 
 	defer func() {
-		ctr.wgProcesses.Done()
-		ctr.deleteProcess(pid)
-		ctr.closeProcessStreams(pid)
 		ctr.closeProcessPipes(pid)
+		ctr.closeProcessStreams(pid)
+		ctr.deleteProcess(pid)
+		ctr.wgProcesses.Done()
 	}()
 
 	var wgRouteOutput sync.WaitGroup

--- a/agent.go
+++ b/agent.go
@@ -952,6 +952,35 @@ func (c *container) closeProcessPipes(pid string) {
 	}
 }
 
+func (c *container) closeConsoleSocket(pid string) error {
+	cid := c.container.ID()
+	proc := c.getProcess(pid)
+
+	errMsg := "Could not close process socket pair"
+
+	if proc == nil {
+		return fmt.Errorf("Container %s process %s no longer exists", cid, pid)
+	}
+
+	if proc.consoleSock != nil {
+		if err := proc.consoleSock.Close(); err != nil {
+			return fmt.Errorf("%s: %s", errMsg, err)
+		}
+
+		proc.consoleSock = nil
+	}
+
+	if proc.process.ConsoleSocket != nil {
+		if err := proc.process.ConsoleSocket.Close(); err != nil {
+			return fmt.Errorf("%s: %s", errMsg, err)
+		}
+
+		proc.process.ConsoleSocket = nil
+	}
+
+	return nil
+}
+
 // Executed as a go routine to route stdout and stderr to the TTY channel.
 func (p *pod) routeOutput(seq uint64, stream *os.File, wg *sync.WaitGroup) {
 	fieldLogger := agentLog.WithField("sequence", seq)
@@ -990,6 +1019,7 @@ func (p *pod) runContainerProcess(cid, pid string, terminal bool, started chan e
 
 	defer func() {
 		ctr.closeProcessPipes(pid)
+		ctr.closeConsoleSocket(pid)
 		ctr.closeProcessStreams(pid)
 		ctr.deleteProcess(pid)
 		ctr.wgProcesses.Done()
@@ -1045,6 +1075,12 @@ func (p *pod) runContainerProcess(cid, pid string, terminal bool, started chan e
 	if terminal {
 		termMaster, err := utils.RecvFd(proc.consoleSock)
 		if err != nil {
+			return err
+		}
+
+		// No need to maintain this socket opened after we retrieved
+		// the master end of the terminal.
+		if err := ctr.closeConsoleSocket(pid); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This PR does a bit of cleanup, but it mainly fixes the way the agent should properly wait for the end of any process output, instead of forcing the closure of its output.

Fixes #207 
