### PR TITLE
main: Add a CLI version option

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -207,6 +207,10 @@ func init() {
 var Version = "unknown"
 
 func main() {
+	if len(os.Args) == 2 && os.Args[1] == "--version" {
+		fmt.Printf("%s version %s\n", name, Version)
+		os.Exit(0)
+	}
 
 	agentLog.Logger.Formatter = &logrus.JSONFormatter{TimestampFormat: time.RFC3339Nano}
 	config := newConfig(defaultLogLevel)


### PR DESCRIPTION
Add a `--version` command-line option to allow the agent version to be
queried.

Fixes #212.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>