### PR TITLE
mount: Use 9p2000.L version when mounting 9p filesystem

### DIFF
--- a/syscall.go
+++ b/syscall.go
@@ -32,6 +32,7 @@ import (
 
 const mountPerm = os.FileMode(0755)
 const devPath = "/dev"
+const mntOptions9p = "trans=virtio,version=9p2000.L"
 
 // bindMount bind mounts a source in to a destination, with the recursive
 // flag if needed.
@@ -107,7 +108,7 @@ func mountShareDir(tag string) error {
 		return err
 	}
 
-	return syscall.Mount(tag, mountShareDirDest, type9pFs, syscall.MS_MGC_VAL|syscall.MS_NODEV, "trans=virtio")
+	return syscall.Mount(tag, mountShareDirDest, type9pFs, syscall.MS_MGC_VAL|syscall.MS_NODEV, mntOptions9p)
 }
 
 func unmountShareDir() error {


### PR DESCRIPTION
Using 9p2000.L version helps passing more tests compared to the
standard version. The symlinks are handled in a better way.

Fixes #214

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>