### PR TITLE
agent: apply CPU share constraint

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1428,6 +1428,7 @@ func newContainerCb(pod *pod, data []byte) error {
 				AllowedDevices:   configs.DefaultAllowedDevices,
 				CpuQuota:         payload.Constraints.CPUQuota,
 				CpuPeriod:        payload.Constraints.CPUPeriod,
+				CpuShares:        payload.Constraints.CPUShares,
 			},
 		},
 		Devices: configs.DefaultAutoCreatedDevices,

--- a/api/commands.go
+++ b/api/commands.go
@@ -185,6 +185,9 @@ type Constraints struct {
 
 	// CPUPeriod specifies a period of time in microseconds
 	CPUPeriod uint64
+
+	// CPUShares specifies container's weight vs. other containers
+	CPUShares uint64
 }
 
 // NewContainer describes the format expected by a NEWCONTAINER command.


### PR DESCRIPTION
This patch is to apply CPU share constraint to new containers

fixes #216

Signed-off-by: Julio Montes <julio.montes@intel.com>