### PR TITLE
agent: Increase timeout for hotplugged block devices

### DIFF
--- a/syscall.go
+++ b/syscall.go
@@ -33,6 +33,7 @@ import (
 const mountPerm = os.FileMode(0755)
 const devPath = "/dev"
 const mntOptions9p = "trans=virtio,version=9p2000.L"
+const blockDevDetectionTimeout = 10
 
 // bindMount bind mounts a source in to a destination, with the recursive
 // flag if needed.
@@ -194,7 +195,7 @@ func waitForBlockDevice(deviceName string, isSCSIAddr bool) error {
 	select {
 	case <-doneListening:
 		close(done)
-	case <-time.After(time.Duration(1) * time.Second):
+	case <-time.After(time.Duration(blockDevDetectionTimeout) * time.Second):
 		close(done)
 		return fmt.Errorf("Timed out waiting for device %s", deviceName)
 	}


### PR DESCRIPTION
The timeout of 1 second to wait for a block device to be detected
by the agent was too low in case the system was running on a slow
environment (nested and/or under heavy load).

This commit increase the value from 1 to 10 to leave enough time to
block devices to be detected.

Fixes #218

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>